### PR TITLE
use IpProto instead of Ipv4Proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ unsafe fn ptr_at<T>(ctx: &XdpContext, offset: usize) -> Result<*const T, ()> {
 
 fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     let ethhdr: *const EthHdr = unsafe { ptr_at(&ctx, 0)? };
-    match unsafe { *ethhdr }.protocol()? {
+    match unsafe { *ethhdr }.proto {
         EthProto::Ipv4 => {}
         _ => return Ok(xdp_action::XDP_PASS),
     }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use aya_log_ebpf::info;
 use core::mem;
 use network_types::{
     l2::ethernet::{EthHdr, EthProto, ETH_HDR_LEN},
-    l3::ip::{Ipv4Hdr, Ipv4Proto, IPV4_HDR_LEN},
+    l3::ip::{Ipv4Hdr, IpProto, IPV4_HDR_LEN},
     l4::{tcp::TcpHdr, udp::UdpHdr},
 };
 
@@ -58,12 +58,12 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     let source_addr = u32::from_be(unsafe { *ipv4hdr }.source);
 
     let source_port = match unsafe { *ipv4hdr }.proto {
-        Ipv4Proto::Tcp => {
+        IpProto::Tcp => {
             let tcphdr: *const TcpHdr =
                 unsafe { ptr_at(&ctx, ETH_HDR_LEN + IPV4_HDR_LEN) }?;
             u16::from_be(unsafe { *tcphdr }.source)
         }
-        Ipv4Proto::Udp => {
+        IpProto::Udp => {
             let udphdr: *const UdpHdr =
                 unsafe { ptr_at(&ctx, ETH_HDR_LEN + IPV4_HDR_LEN) }?;
             u16::from_be(unsafe { *udphdr }.source)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! use core::mem;
 //! use network_types::{
 //!     l2::ethernet::{EthHdr, EthProto, ETH_HDR_LEN},
-//!     l3::ip::{Ipv4Hdr, Ipv4Proto, IPV4_HDR_LEN},
+//!     l3::ip::{Ipv4Hdr, IpProto, IPV4_HDR_LEN},
 //!     l4::{tcp::TcpHdr, udp::UdpHdr},
 //! };
 //!
@@ -56,12 +56,12 @@
 //!     let source_addr = u32::from_be(unsafe { *ipv4hdr }.source);
 //!
 //!     let source_port = match unsafe { *ipv4hdr }.proto {
-//!         Ipv4Proto::Tcp => {
+//!         IpProto::Tcp => {
 //!             let tcphdr: *const TcpHdr =
 //!                 unsafe { ptr_at(&ctx, ETH_HDR_LEN + IPV4_HDR_LEN) }?;
 //!             u16::from_be(unsafe { *tcphdr }.source)
 //!         }
-//!         Ipv4Proto::Udp => {
+//!         IpProto::Udp => {
 //!             let udphdr: *const UdpHdr =
 //!                 unsafe { ptr_at(&ctx, ETH_HDR_LEN + IPV4_HDR_LEN) }?;
 //!             u16::from_be(unsafe { *udphdr }.source)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //! fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
 //!     let ethhdr: *const EthHdr = unsafe { ptr_at(&ctx, 0)? };
-//!     match unsafe { *ethhdr }.protocol()? {
+//!     match unsafe { *ethhdr }.proto {
 //!         EthProto::Ipv4 => {}
 //!         _ => return Ok(xdp_action::XDP_PASS),
 //!     }


### PR DESCRIPTION
Re https://github.com/vadorovsky/network-types/pull/3#issuecomment-1363995417 - thanks for making the change, this small addition is to bring the docs in sync with the new names