### PR TITLE
chore: release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.5](https://github.com/vadorovsky/network-types/compare/v0.0.4...v0.0.5) - 2023-11-30
+
+### Added
+- add std feature flag that exposes std types ([#7](https://github.com/vadorovsky/network-types/pull/7))
+
+### Fixed
+- Convert addresses from/to big-endian ([#8](https://github.com/vadorovsky/network-types/pull/8))
+
+### Other
+- Add release-plz action
+- Add serde support to structs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-types"
-version = "0.0.4"
+version = "0.0.5"
 description = "Rust structs representing network-related types in Linux."
 keywords = ["linux", "network", "osi", "packet", "headers"]
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `network-types`: 0.0.4 -> 0.0.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.5](https://github.com/vadorovsky/network-types/compare/v0.0.4...v0.0.5) - 2023-11-30

### Added
- add std feature flag that exposes std types ([#7](https://github.com/vadorovsky/network-types/pull/7))

### Fixed
- Convert addresses from/to big-endian ([#8](https://github.com/vadorovsky/network-types/pull/8))

### Other
- Add release-plz action
- Add serde support to structs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).