### PR TITLE
fix: follow rename of aya-bpf to aya-ebpf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
-aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
+aya-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! ```rust
 //! use core::mem;
 //!
-//! use aya_bpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
+//! use aya_ebpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
 //! use aya_log_ebpf::info;
 //!
 //! use network_types::{


### PR DESCRIPTION
Currently we reference the invalid crate `aya_bpf` in the dev dependencies causing tools like rust-analyzer to fail.
It was renamed to `aya_ebpf`.