### PR TITLE
doc: Use `src_addr` methods from IP header structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     match unsafe { *ethhdr }.ether_type {
         EtherType::Ipv4 => {
             let ipv4hdr: *const Ipv4Hdr = unsafe { ptr_at(&ctx, EthHdr::LEN)? };
-            let source_addr = unsafe { (*ipv4hdr).src_addr };
+            let source_addr = unsafe { (*ipv4hdr).src_addr() };
 
             let source_port = match unsafe { (*ipv4hdr).proto } {
                 IpProto::Tcp => {
@@ -70,7 +70,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
         }
         EtherType::Ipv6 => {
             let ipv6hdr: *const Ipv6Hdr = unsafe { ptr_at(&ctx, EthHdr::LEN)? };
-            let source_addr = unsafe { (*ipv6hdr).src_addr.in6_u.u6_addr8 };
+            let source_addr = unsafe { (*ipv6hdr).src_addr() };
 
             let source_port = match unsafe { (*ipv6hdr).next_hdr } {
                 IpProto::Tcp => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!     match unsafe { *ethhdr }.ether_type {
 //!         EtherType::Ipv4 => {
 //!             let ipv4hdr: *const Ipv4Hdr = unsafe { ptr_at(&ctx, EthHdr::LEN)? };
-//!             let source_addr = unsafe { (*ipv4hdr).src_addr };
+//!             let source_addr = unsafe { (*ipv4hdr).src_addr() };
 //!
 //!             let source_port = match unsafe { (*ipv4hdr).proto } {
 //!                 IpProto::Tcp => {
@@ -68,7 +68,7 @@
 //!         }
 //!         EtherType::Ipv6 => {
 //!             let ipv6hdr: *const Ipv6Hdr = unsafe { ptr_at(&ctx, EthHdr::LEN)? };
-//!             let source_addr = unsafe { (*ipv6hdr).src_addr.in6_u.u6_addr8 };
+//!             let source_addr = unsafe { (*ipv6hdr).src_addr() };
 //!
 //!             let source_port = match unsafe { (*ipv6hdr).next_hdr } {
 //!                 IpProto::Tcp => {


### PR DESCRIPTION
They take care of handling the endianness.