### PR TITLE
refactor(udp): store fields as byte-arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
                 IpProto::Udp => {
                     let udphdr: *const UdpHdr =
                         unsafe { ptr_at(&ctx, EthHdr::LEN + Ipv4Hdr::LEN) }?;
-                    u16::from_be(unsafe { (*udphdr).source })
+                    unsafe { (*udphdr).source() }
                 }
                 _ => return Ok(xdp_action::XDP_PASS),
             };
@@ -81,7 +81,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
                 IpProto::Udp => {
                     let udphdr: *const UdpHdr =
                         unsafe { ptr_at(&ctx, EthHdr::LEN + Ipv6Hdr::LEN) }?;
-                    u16::from_be(unsafe { (*udphdr).source })
+                    unsafe { (*udphdr).source() }
                 }
                 _ => return Ok(xdp_action::XDP_PASS),
             };

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -5,14 +5,46 @@ use core::mem;
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct UdpHdr {
-    pub source: u16,
-    pub dest: u16,
-    pub len: u16,
-    pub check: u16,
+    pub source: [u8; 2],
+    pub dest: [u8; 2],
+    pub len: [u8; 2],
+    pub check: [u8; 2],
 }
 
 impl UdpHdr {
     pub const LEN: usize = mem::size_of::<UdpHdr>();
+
+    pub fn source(&self) -> u16 {
+        u16::from_be_bytes(self.source)
+    }
+
+    pub fn set_source(&mut self, source: u16) {
+        self.source = source.to_be_bytes();
+    }
+
+    pub fn dest(&self) -> u16 {
+        u16::from_be_bytes(self.dest)
+    }
+
+    pub fn set_dest(&mut self, dest: u16) {
+        self.dest = dest.to_be_bytes();
+    }
+
+    pub fn len(&self) -> u16 {
+        u16::from_be_bytes(self.len)
+    }
+
+    pub fn set_len(&mut self, len: u16) {
+        self.len = len.to_be_bytes();
+    }
+
+    pub fn check(&self) -> u16 {
+        u16::from_be_bytes(self.check)
+    }
+
+    pub fn set_check(&mut self, check: u16) {
+        self.check = check.to_be_bytes();
+    }
 }
 
 #[cfg(test)]
@@ -24,10 +56,10 @@ mod test {
         use bincode::{config::standard, serde::encode_to_vec};
 
         let udp = UdpHdr {
-            source: 4242,
-            dest: 4789,
-            len: 42,
-            check: 0,
+            source: 4242_u16.to_be_bytes(),
+            dest: 4789_u16.to_be_bytes(),
+            len: 42_u16.to_be_bytes(),
+            check: 0_u16.to_be_bytes(),
         };
 
         let options = standard().with_fixed_int_encoding().with_big_endian();


### PR DESCRIPTION
Within the actual network packet, this data is encoded as big-endian. By representing the fields as byte-arrays, we can preserve this encoding and the use getters and setters to correctly convert to and from the host endianness.

Related: #32