### PR TITLE
ci: Update Ubuntu to latest

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,7 +13,7 @@ jobs:
 
   release-plz:
     name: release-plz
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       # Generating a GitHub token, so that PRs and tags created by
       # the release-plz-action can trigger actions workflows.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Ubuntu 20.04 was removed from runners, because it's unsupported.