### PR TITLE
Multi-target CI Stages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,60 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+        target:
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - riscv64gc-unknown-linux-gnu
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
+      RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-
-      - name: Test
-        env:
-          RUST_BACKTRACE: full
+      - name: Install cross-compilation tools
         run: |
-          cargo test --verbose
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu musl-tools
+
+      - name: Configure Cargo for cross-compilation
+        run: |
+          mkdir -p .cargo
+          cat > .cargo/config.toml <<EOL
+          [target.aarch64-unknown-linux-gnu]
+          linker = "aarch64-linux-gnu-gcc"
+
+          [target.aarch64-unknown-linux-musl]
+          linker = "aarch64-linux-gnu-gcc"
+
+          [target.riscv64gc-unknown-linux-gnu]
+          linker = "riscv64-linux-gnu-gcc"
+          EOL
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy, rust-src
+          targets: ${{ matrix.target }}
+
+      - name: Check formatting
+        if: matrix.rust == 'stable'
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy -- --deny warnings -A clippy::useless_transmute -A clippy::too_many_arguments
+
+      - name: Build tests for cross-targets
+        if: contains(matrix.target, 'aarch64') || contains(matrix.target, 'riscv64')
+        run: cargo build --tests --verbose
+
+      - name: Run tests on native target
+        if: contains(matrix.target, 'x86_64')
+        run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -118,6 +118,4 @@ feature flag. It is intended to be used with binary serialization libraries
 like [`bincode`](https://crates.io/crates/bincode) that leverage Serde's
 infrastructure.
 
-Note that `no_std` support is lost when enabling Serde.
-
 License: MIT

--- a/src/geneve.rs
+++ b/src/geneve.rs
@@ -1,6 +1,6 @@
 /// Represents a Geneve (Generic Network Virtualization Encapsulation) header, according to RFC 8926.
 /// Geneve is an encapsulation protocol designed for network virtualization.
-
+///
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, Default)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 pub mod arp;
 pub mod bitfield;


### PR DESCRIPTION
__CHANGES:__

Following up on https://github.com/vadorovsky/network-types/pull/46, this pr makes a few additional changes:

1. Drop the nightly target for the big-endian and little-endian BPF Linux targets, as they don't seem to be built in nightly due to their tier 3 status.
2. Drop the wasm build target for now. (Is this something that network types would need to build for?)
3. Add cross compilation for aarch64-based builds in CI since CI is amd64-based.
4. Add the std feature in cargo for testing with/without std