### PR TITLE
perf: Reduce number of instructions in setters and getters

### DIFF
--- a/src/arp.rs
+++ b/src/arp.rs
@@ -1,5 +1,7 @@
 use core::mem::{self};
-use memoffset::offset_of;
+
+use crate::{getter_be, setter_be};
+
 /// Represents an Address Resolution Protocol (ARP) header.
 ///
 /// The ARP header is typically found after the Ethernet header and is used to
@@ -49,8 +51,8 @@ impl ArpHdr {
     /// Returns the hardware type field.
     #[inline]
     pub fn htype(&self) -> u16 {
-        unsafe { *((self as *const Self as usize + offset_of!(Self, htype)) as *const u16) }
-            .swap_bytes()
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, htype, u16) }
     }
 
     /// Sets the hardware type field.
@@ -60,14 +62,15 @@ impl ArpHdr {
     /// * `htype` - A 2-byte array representing the hardware type.
     #[inline]
     pub fn set_htype(&mut self, htype: u16) {
-        self.htype = unsafe { *((&htype.swap_bytes() as *const _ as usize) as *const _) };
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, htype, htype) }
     }
 
     /// Returns the protocol type field.
     #[inline]
     pub fn ptype(&self) -> u16 {
-        unsafe { *((self as *const Self as usize + offset_of!(Self, ptype)) as *const u16) }
-            .swap_bytes()
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, ptype, u16) }
     }
 
     /// Sets the protocol type field.
@@ -77,7 +80,8 @@ impl ArpHdr {
     /// * `ptype` - A 2-byte array representing the protocol type.
     #[inline]
     pub fn set_ptype(&mut self, ptype: u16) {
-        self.ptype = unsafe { *((&ptype.swap_bytes() as *const _ as usize) as *const _) };
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, ptype, ptype) }
     }
 
     /// Returns the hardware address length field.
@@ -115,8 +119,8 @@ impl ArpHdr {
     /// Returns the operation field.
     #[inline]
     pub fn oper(&self) -> u16 {
-        unsafe { *((self as *const Self as usize + offset_of!(Self, oper)) as *const u16) }
-            .swap_bytes()
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, oper, u16) }
     }
 
     /// Sets the operation field.
@@ -126,7 +130,8 @@ impl ArpHdr {
     /// * `oper` - A 2-byte array representing the operation (e.g., request or reply).
     #[inline]
     pub fn set_oper(&mut self, oper: u16) {
-        self.oper = unsafe { *((&oper.swap_bytes() as *const _ as usize) as *const _) };
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, oper, oper) }
     }
 
     /// Returns the sender hardware address (SHA) field.

--- a/src/geneve.rs
+++ b/src/geneve.rs
@@ -1,3 +1,5 @@
+use crate::{getter_be, setter_be};
+
 /// Represents a Geneve (Generic Network Virtualization Encapsulation) header, according to RFC 8926.
 /// Geneve is an encapsulation protocol designed for network virtualization.
 ///
@@ -92,7 +94,8 @@ impl GeneveHdr {
     /// This follows the Ethertype convention.
     #[inline]
     pub fn protocol_type(&self) -> u16 {
-        u16::from_be_bytes(self.protocol_type)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, protocol_type, u16) }
     }
 
     /// Sets the Protocol Type (16 bits).
@@ -100,7 +103,8 @@ impl GeneveHdr {
     /// The value is stored in network byte order.
     #[inline]
     pub fn set_protocol_type(&mut self, protocol_type: u16) {
-        self.protocol_type = protocol_type.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, protocol_type, protocol_type) }
     }
 
     /// Returns the Virtual Network Identifier (VNI) (24 bits).

--- a/src/icmp.rs
+++ b/src/icmp.rs
@@ -1,6 +1,9 @@
 use core::mem;
 use core::net;
 
+use crate::getter_be;
+use crate::setter_be;
+
 /// An enum representing either an ICMPv4 or ICMPv6 header.
 ///
 /// - `V4` contains an IPv4 ICMP header as defined in RFC 792 (see `IcmpHdr`)
@@ -57,14 +60,16 @@ impl IcmpHdr {
     /// Returns the ICMP header checksum value in host byte order.
     /// This field is used to detect data corruption in the ICMP header and payload.
     pub fn checksum(&self) -> u16 {
-        u16::from_be_bytes(self.check)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, check, u16) }
     }
 
     /// Sets the ICMP header checksum field to the given value.
     /// The checksum value should be calculated over the entire ICMP message (header and payload)
     /// according to RFC 792. The value will be stored in network byte order.
     pub fn set_checksum(&mut self, checksum: u16) {
-        self.check = checksum.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, check, checksum) }
     }
 
     /// Returns the identification field from ICMP Echo/Timestamp/Info/Mask messages.
@@ -259,7 +264,7 @@ impl IcmpHdr {
     /// in undefined behavior.
     #[inline]
     pub unsafe fn echo_id_unchecked(&self) -> u16 {
-        u16::from_be_bytes(self.data.echo.id)
+        self.data.echo.id_unchecked()
     }
 
     /// Sets the identification field for ICMP Echo/Timestamp/Info/Mask messages.
@@ -271,7 +276,7 @@ impl IcmpHdr {
     /// in undefined behavior.
     #[inline]
     pub unsafe fn set_echo_id_unchecked(&mut self, id: u16) {
-        self.data.echo.id = id.to_be_bytes();
+        self.data.echo.set_id_unchecked(id);
     }
 
     /// Returns the sequence number from ICMP Echo/Timestamp/Info/Mask messages.
@@ -283,7 +288,7 @@ impl IcmpHdr {
     /// in undefined behavior.
     #[inline]
     pub unsafe fn echo_sequence_unchecked(&self) -> u16 {
-        u16::from_be_bytes(self.data.echo.sequence)
+        self.data.echo.sequence_unchecked()
     }
 
     /// Sets the sequence number for ICMP Echo/Timestamp/Info/Mask messages.
@@ -295,7 +300,7 @@ impl IcmpHdr {
     /// in undefined behavior.
     #[inline]
     pub unsafe fn set_echo_sequence_unchecked(&mut self, sequence: u16) {
-        self.data.echo.sequence = sequence.to_be_bytes();
+        self.data.echo.set_sequence_unchecked(sequence);
     }
 
     /// Returns the gateway internet address from an ICMP Redirect message (Type 5)
@@ -326,7 +331,7 @@ impl IcmpHdr {
     /// Accessing the dst_unreachable field with other ICMP types may result in undefined behavior.
     #[inline]
     pub unsafe fn next_hop_mtu_unchecked(&self) -> u16 {
-        u16::from_be_bytes(self.data.dst_unreachable.mtu)
+        self.data.dst_unreachable.mtu_unchecked()
     }
 
     /// Sets the Next-Hop MTU field for a Destination Unreachable message.
@@ -337,7 +342,7 @@ impl IcmpHdr {
     /// Accessing the dst_unreachable field with other ICMP types may result in undefined behavior.
     #[inline]
     pub unsafe fn set_next_hop_mtu_unchecked(&mut self, mtu: u16) {
-        self.data.dst_unreachable.mtu = mtu.to_be_bytes();
+        self.data.dst_unreachable.set_mtu_unchecked(mtu)
     }
 
     /// Returns the pointer to the errored byte from a Parameter Problem message (Type 12)
@@ -369,7 +374,7 @@ impl IcmpHdr {
     /// this function. Accessing the traceroute field with other ICMP types may result in undefined behavior.
     #[inline]
     pub unsafe fn traceroute_id_unchecked(&self) -> u16 {
-        u16::from_be_bytes(self.data.traceroute.id)
+        self.data.traceroute.id_unchecked()
     }
 
     /// Sets the ID Number field for a Traceroute message (Type 30).
@@ -380,7 +385,7 @@ impl IcmpHdr {
     /// this function. Accessing the traceroute field with other ICMP types may result in undefined behavior.
     #[inline]
     pub unsafe fn set_traceroute_id_unchecked(&mut self, id: u16) {
-        self.data.traceroute.id = id.to_be_bytes();
+        self.data.traceroute.set_id_unchecked(id);
     }
 
     /// Returns the Security Parameters Index (SPI) from a PHOTURIS message (Type 40).
@@ -391,7 +396,7 @@ impl IcmpHdr {
     /// Accessing the photuris field with other ICMP types may result in undefined behavior.
     #[inline]
     pub unsafe fn photuris_spi_unchecked(&self) -> u16 {
-        u16::from_be_bytes(self.data.photuris.reserved_spi)
+        self.data.photuris.reserved_spi_unchecked()
     }
 
     /// Sets the Security Parameters Index (SPI) for a PHOTURIS message (Type 40).
@@ -402,7 +407,7 @@ impl IcmpHdr {
     /// Accessing the photuris field with other ICMP types may result in undefined behavior.
     #[inline]
     pub unsafe fn set_photuris_spi_unchecked(&mut self, spi: u16) {
-        self.data.photuris.reserved_spi = spi.to_be_bytes();
+        self.data.photuris.set_reserved_spi_unckecked(spi);
     }
 
     /// Returns the pointer to the byte where an error was detected in a PHOTURIS message (Type 40).
@@ -413,7 +418,7 @@ impl IcmpHdr {
     /// Accessing the photuris field with other ICMP types may result in undefined behavior.
     #[inline]
     pub unsafe fn photuris_pointer_unchecked(&self) -> u16 {
-        u16::from_be_bytes(self.data.photuris.pointer)
+        self.data.photuris.pointer_unchecked()
     }
 
     /// Sets the pointer to the byte where an error was detected in a PHOTURIS message (Type 40).
@@ -424,7 +429,7 @@ impl IcmpHdr {
     /// Accessing the photuris field with other ICMP types may result in undefined behavior.
     #[inline]
     pub unsafe fn set_photuris_pointer_unchecked(&mut self, pointer: u16) {
-        self.data.photuris.pointer = pointer.to_be_bytes();
+        self.data.photuris.set_pointer_unchecked(pointer);
     }
 }
 
@@ -482,6 +487,56 @@ pub struct IcmpEcho {
     pub sequence: [u8; 2],
 }
 
+impl IcmpEcho {
+    /// Returns the identification field from ICMP Echo/Timestamp/Info/Mask messages.
+    /// Only valid for ICMP Types: 0, 8, 13, 14, 15, 16, 17, 18, 37, 38.
+    ///
+    /// # Safety
+    /// Caller must ensure that the ICMP type is one of: 0, 8, 13, 14, 15, 16, 17, 18, 37, 38
+    /// before calling this function. Accessing the echo fields with other ICMP types may result
+    /// in undefined behavior.
+    #[inline]
+    unsafe fn id_unchecked(&self) -> u16 {
+        getter_be!(self, id, u16)
+    }
+
+    /// Sets the identification field for ICMP Echo/Timestamp/Info/Mask messages.
+    /// Only valid for ICMP Types: 0, 8, 13, 14, 15, 16, 17, 18, 37, 38.
+    ///
+    /// # Safety
+    /// Caller must ensure that the ICMP type is one of: 0, 8, 13, 14, 15, 16, 17, 18, 37, 38
+    /// before calling this function. Accessing the echo fields with other ICMP types may result
+    /// in undefined behavior.
+    #[inline]
+    unsafe fn set_id_unchecked(&mut self, id: u16) {
+        setter_be!(self, id, id)
+    }
+
+    /// Returns the sequence number from ICMP Echo/Timestamp/Info/Mask messages.
+    /// Only valid for ICMP Types: 0, 8, 13, 14, 15, 16, 17, 18, 37, 38.
+    ///
+    /// # Safety
+    /// Caller must ensure that the ICMP type is one of: 0, 8, 13, 14, 15, 16, 17, 18, 37, 38
+    /// before calling this function. Accessing the echo fields with other ICMP types may result
+    /// in undefined behavior.
+    #[inline]
+    unsafe fn sequence_unchecked(&self) -> u16 {
+        getter_be!(self, sequence, u16)
+    }
+
+    /// Sets the sequence number for ICMP Echo/Timestamp/Info/Mask messages.
+    /// Only valid for ICMP Types: 0, 8, 13, 14, 15, 16, 17, 18, 37, 38.
+    ///
+    /// # Safety
+    /// Caller must ensure that the ICMP type is one of: 0, 8, 13, 14, 15, 16, 17, 18, 37, 38
+    /// before calling this function. Accessing the echo fields with other ICMP types may result
+    /// in undefined behavior.
+    #[inline]
+    unsafe fn set_sequence_unchecked(&mut self, sequence: u16) {
+        setter_be!(self, sequence, sequence)
+    }
+}
+
 /// For ICMP Type 3 "Destination Unreachable" Message (RFC 792) with support for PMTUD (RFC 1191)
 /// Contains 2 unused bytes followed by a Next-Hop MTU field indicating the maximum transmission unit
 /// of the next-hop network on which fragmentation is required.
@@ -491,6 +546,24 @@ pub struct IcmpEcho {
 pub struct IcmpDstUnreachable {
     pub _unused: [u8; 2],
     pub mtu: [u8; 2],
+}
+
+impl IcmpDstUnreachable {
+    /// Returns the Next-Hop MTU field from a Destination Unreachable message
+    /// in host byte order. Used for Path MTU Discovery (RFC 1191).
+    ///
+    /// # Safety
+    /// Caller must ensure ICMP type is 3 (Destination Unreachable) before calling this function.
+    /// Accessing the dst_unreachable field with other ICMP types may result in undefined behavior.
+    #[inline]
+    unsafe fn mtu_unchecked(&self) -> u16 {
+        getter_be!(self, mtu, u16)
+    }
+
+    #[inline]
+    unsafe fn set_mtu_unchecked(&mut self, mtu: u16) {
+        setter_be!(self, mtu, mtu)
+    }
 }
 
 /// For ICMP Type 12 "Parameter Problem" Message (RFC 792)
@@ -516,6 +589,28 @@ pub struct IcmpHdrPhoturis {
     pub pointer: [u8; 2],
 }
 
+impl IcmpHdrPhoturis {
+    #[inline]
+    unsafe fn reserved_spi_unchecked(&self) -> u16 {
+        getter_be!(self, reserved_spi, u16)
+    }
+
+    #[inline]
+    unsafe fn set_reserved_spi_unckecked(&mut self, spi: u16) {
+        setter_be!(self, reserved_spi, spi)
+    }
+
+    #[inline]
+    unsafe fn pointer_unchecked(&self) -> u16 {
+        getter_be!(self, pointer, u16)
+    }
+
+    #[inline]
+    unsafe fn set_pointer_unchecked(&mut self, pointer: u16) {
+        setter_be!(self, pointer, pointer)
+    }
+}
+
 /// For ICMP Type 30 "Traceroute" Message (RFC 1393)
 /// Contains a 16-bit ID Number field used by the source to match responses to outgoing requests
 /// followed by 2 unused bytes to make a total of 4 bytes. The ID Number helps match Reply messages
@@ -526,6 +621,31 @@ pub struct IcmpHdrPhoturis {
 pub struct IcmpTraceroute {
     pub id: [u8; 2],
     pub _unused: [u8; 2],
+}
+
+impl IcmpTraceroute {
+    /// Returns the ID Number field from a Traceroute message (Type 30).
+    /// The ID Number is used to match Reply messages (Type 31) to their corresponding Request messages.
+    /// This is only valid for ICMP Type 30 (Traceroute Request) and Type 31 (Traceroute Reply).
+    ///
+    /// # Safety
+    /// Caller must ensure ICMP type is 30 (Traceroute Request) or 31 (Traceroute Reply) before calling
+    /// this function. Accessing the traceroute field with other ICMP types may result in undefined behavior.
+    #[inline]
+    unsafe fn id_unchecked(&self) -> u16 {
+        getter_be!(self, id, u16)
+    }
+
+    /// Sets the ID Number field for a Traceroute message (Type 30).
+    /// The ID Number is used to match Reply messages (Type 31) to their corresponding Request messages.
+    ///
+    /// # Safety
+    /// Caller must ensure ICMP type is 30 (Traceroute Request) or 31 (Traceroute Reply) before calling
+    /// this function. Accessing the traceroute field with other ICMP types may result in undefined behavior.
+    #[inline]
+    unsafe fn set_id_unchecked(&mut self, id: u16) {
+        setter_be!(self, id, id)
+    }
 }
 
 /// Represents the variable length portion of a Timestamp Request/Reply message (RFC 792)
@@ -614,35 +734,41 @@ impl IcmpTimestampMsgPart {
 
     /// Returns the originate timestamp in host byte order (milliseconds since midnight UT)
     pub fn originate_timestamp(&self) -> u32 {
-        u32::from_be_bytes(self.originate_timestamp)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, originate_timestamp, u32) }
     }
 
     /// Sets the originate timestamp field (milliseconds since midnight UT).
     /// The value will be stored in network byte order.
     pub fn set_originate_timestamp(&mut self, timestamp: u32) {
-        self.originate_timestamp = timestamp.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, originate_timestamp, timestamp) }
     }
 
     /// Returns the receive timestamp in host byte order (milliseconds since midnight UT)
     pub fn receive_timestamp(&self) -> u32 {
-        u32::from_be_bytes(self.receive_timestamp)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, receive_timestamp, u32) }
     }
 
     /// Sets the receive timestamp field (milliseconds since midnight UT).
     /// The value will be stored in network byte order.
     pub fn set_receive_timestamp(&mut self, timestamp: u32) {
-        self.receive_timestamp = timestamp.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, receive_timestamp, timestamp) }
     }
 
     /// Returns the transmit timestamp in host byte order (milliseconds since midnight UT)
     pub fn transmit_timestamp(&self) -> u32 {
-        u32::from_be_bytes(self.transmit_timestamp)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, transmit_timestamp, u32) }
     }
 
     /// Sets the transmit timestamp field (milliseconds since midnight UT).
     /// The value will be stored in network byte order.
     pub fn set_transmit_timestamp(&mut self, timestamp: u32) {
-        self.transmit_timestamp = timestamp.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, transmit_timestamp, timestamp) }
     }
 }
 
@@ -718,49 +844,57 @@ impl IcmpTracerouteMsgPart {
     /// Returns the outbound hop count in host byte order.
     /// This indicates the maximum number of hops that can be traversed to the target.
     pub fn hops_out(&self) -> u16 {
-        u16::from_be_bytes(self.hops_out)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, hops_out, u16) }
     }
 
     /// Sets the outbound hop count field. The value will be stored in network byte order.
     /// This should be set to the maximum number of hops that can be traversed to the target.
     pub fn set_hops_out(&mut self, hops: u16) {
-        self.hops_out = hops.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, hops_out, hops) }
     }
 
     /// Returns the inbound hop count in host byte order.
     /// This indicates the maximum number of hops that can be traversed in the return path.
     pub fn hops_in(&self) -> u16 {
-        u16::from_be_bytes(self.hops_in)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, hops_in, u16) }
     }
 
     /// Sets the inbound hop count field. The value will be stored in network byte order.
     /// This should be set to the maximum number of hops that can be traversed in the return path.
     pub fn set_hops_in(&mut self, hops: u16) {
-        self.hops_in = hops.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, hops_in, hops) }
     }
 
     /// Returns the outbound bandwidth estimate in host byte order.
     /// This represents the minimum bandwidth along the forward path in bytes per second.
     pub fn bandwidth_out(&self) -> u32 {
-        u32::from_be_bytes(self.bandwidth_out)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, bandwidth_out, u32) }
     }
 
     /// Sets the outbound bandwidth field. The value will be stored in network byte order.
     /// This should be set to the minimum bandwidth along the forward path in bytes per second.
     pub fn set_bandwidth_out(&mut self, bandwidth: u32) {
-        self.bandwidth_out = bandwidth.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, bandwidth_out, bandwidth) }
     }
 
     /// Returns the outbound MTU in host byte order.
     /// This represents the minimum MTU along the forward path in bytes.
     pub fn mtu_out(&self) -> u32 {
-        u32::from_be_bytes(self.mtu_out)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, mtu_out, u32) }
     }
 
     /// Sets the outbound MTU field. The value will be stored in network byte order.
     /// This should be set to the minimum MTU along the forward path in bytes.
     pub fn set_mtu_out(&mut self, mtu: u32) {
-        self.mtu_out = mtu.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, mtu_out, mtu) }
     }
 }
 
@@ -810,6 +944,28 @@ pub union IcmpV6HdrUn {
     pub reserved: [u8; 4],
 }
 
+impl IcmpV6HdrUn {
+    #[inline]
+    unsafe fn mtu_unchecked(&self) -> u32 {
+        getter_be!(self, packet_too_big_mtu, u32)
+    }
+
+    #[inline]
+    unsafe fn set_mtu_unchecked(&mut self, mtu: u32) {
+        setter_be!(self, packet_too_big_mtu, mtu)
+    }
+
+    #[inline]
+    unsafe fn pointer_unchecked(&self) -> u32 {
+        getter_be!(self, param_problem_pointer, u32)
+    }
+
+    #[inline]
+    unsafe fn set_pointer_unchecked(&mut self, pointer: u32) {
+        setter_be!(self, param_problem_pointer, pointer)
+    }
+}
+
 impl core::fmt::Debug for IcmpV6HdrUn {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Safe approach: just show the raw 4 bytes
@@ -837,14 +993,16 @@ impl IcmpV6Hdr {
     /// Returns the ICMPv6 header checksum value in host byte order.
     /// This field is used to detect corruption in the ICMPv6 header and payload.
     pub fn checksum(&self) -> u16 {
-        u16::from_be_bytes(self.check)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, check, u16) }
     }
 
     /// Sets the ICMPv6 header checksum field to the given value.
     /// The checksum value should be calculated over the pseudo-header, ICMPv6 header, and payload
     /// according to RFC 4443. The value will be stored in network byte order.
     pub fn set_checksum(&mut self, checksum: u16) {
-        self.check = checksum.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, check, checksum) }
     }
 
     /// Returns the identification field from ICMPv6 Echo Request/Reply messages.
@@ -1021,7 +1179,7 @@ impl IcmpV6Hdr {
     /// Accessing echo fields with other types may result in undefined behavior.
     #[inline]
     pub unsafe fn echo_id_unchecked(&self) -> u16 {
-        u16::from_be_bytes(self.data.echo.id)
+        self.data.echo.id_unchecked()
     }
 
     /// Sets the identification field for ICMPv6 Echo Request/Reply messages.
@@ -1032,7 +1190,7 @@ impl IcmpV6Hdr {
     /// Accessing echo fields with other types may result in undefined behavior.
     #[inline]
     pub unsafe fn set_echo_id_unchecked(&mut self, id: u16) {
-        self.data.echo.id = id.to_be_bytes();
+        self.data.echo.set_id_unchecked(id);
     }
 
     /// Returns the sequence number from ICMPv6 Echo Request/Reply messages.
@@ -1043,7 +1201,7 @@ impl IcmpV6Hdr {
     /// Accessing echo fields with other types may result in undefined behavior.
     #[inline]
     pub unsafe fn echo_sequence_unchecked(&self) -> u16 {
-        u16::from_be_bytes(self.data.echo.sequence)
+        self.data.echo.sequence_unchecked()
     }
 
     /// Sets the sequence number for ICMPv6 Echo Request/Reply messages.
@@ -1054,7 +1212,7 @@ impl IcmpV6Hdr {
     /// Accessing echo fields with other types may result in undefined behavior.
     #[inline]
     pub unsafe fn set_echo_sequence_unchecked(&mut self, sequence: u16) {
-        self.data.echo.sequence = sequence.to_be_bytes();
+        self.data.echo.set_sequence_unchecked(sequence);
     }
 
     /// Returns the MTU field from an ICMPv6 Packet Too Big message (Type 2).
@@ -1065,7 +1223,7 @@ impl IcmpV6Hdr {
     /// Accessing MTU field with other types may result in undefined behavior.
     #[inline]
     pub unsafe fn mtu_unchecked(&self) -> u32 {
-        u32::from_be_bytes(self.data.packet_too_big_mtu)
+        self.data.mtu_unchecked()
     }
 
     /// Sets the MTU field for an ICMPv6 Packet Too Big message (Type 2).
@@ -1076,7 +1234,7 @@ impl IcmpV6Hdr {
     /// Accessing MTU field with other types may result in undefined behavior.
     #[inline]
     pub unsafe fn set_mtu_unchecked(&mut self, mtu: u32) {
-        self.data.packet_too_big_mtu = mtu.to_be_bytes();
+        self.data.set_mtu_unchecked(mtu);
     }
 
     /// Returns the pointer field from an ICMPv6 Parameter Problem message (Type 4).
@@ -1087,7 +1245,7 @@ impl IcmpV6Hdr {
     /// Accessing pointer field with other types may result in undefined behavior.
     #[inline]
     pub unsafe fn pointer_unchecked(&self) -> u32 {
-        u32::from_be_bytes(self.data.param_problem_pointer)
+        self.data.pointer_unchecked()
     }
 
     /// Sets the pointer field for an ICMPv6 Parameter Problem message (Type 4).
@@ -1098,7 +1256,7 @@ impl IcmpV6Hdr {
     /// Accessing pointer field with other types may result in undefined behavior.
     #[inline]
     pub unsafe fn set_pointer_unchecked(&mut self, pointer: u32) {
-        self.data.param_problem_pointer = pointer.to_be_bytes();
+        self.data.set_pointer_unchecked(pointer);
     }
 
     /// Returns the 4-byte reserved field from an ICMPv6 Redirect message (Type 137).

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1,5 +1,7 @@
 use core::mem;
 
+use crate::{getter_be, setter_be};
+
 /// IP headers, which are present after the Ethernet header.
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub enum IpHdr {
@@ -67,56 +69,69 @@ impl Ipv4Hdr {
     /// Returns the total length of the IP packet.
     #[inline]
     pub fn tot_len(&self) -> u16 {
-        u16::from_be_bytes(self.tot_len)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, tot_len, u16) }
     }
 
     /// Sets the total length of the IP packet.
     #[inline]
     pub fn set_tot_len(&mut self, len: u16) {
-        self.tot_len = len.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, tot_len, len) }
     }
 
     /// Returns the identification field.
     #[inline]
     pub fn id(&self) -> u16 {
-        u16::from_be_bytes(self.id)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, id, u16) }
     }
 
     /// Sets the identification field.
     #[inline]
     pub fn set_id(&mut self, id: u16) {
-        self.id = id.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, id, id) }
+    }
+
+    #[inline]
+    fn frags(&self) -> u16 {
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, frags, u16) }
     }
 
     /// Returns the fragmentation flags (3 bits).
     #[inline]
     pub fn frag_flags(&self) -> u8 {
-        (u16::from_be_bytes(self.frags) >> 13) as u8
+        (self.frags() >> 13) as u8
     }
 
     /// Returns the fragmentation offset (13 bits).
     #[inline]
     pub fn frag_offset(&self) -> u16 {
-        u16::from_be_bytes(self.frags) & 0x1FFF
+        self.frags() & 0x1FFF
     }
 
     /// Sets both the fragmentation flags and offset.
     #[inline]
     pub fn set_frags(&mut self, flags: u8, offset: u16) {
         let value = ((flags as u16 & 0x7) << 13) | (offset & 0x1FFF);
-        self.frags = value.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, frags, value) }
     }
 
     /// Returns the checksum field.
     #[inline]
     pub fn checksum(&self) -> u16 {
-        u16::from_be_bytes(self.check)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, check, u16) }
     }
 
     /// Sets the checksum field.
     #[inline]
     pub fn set_checksum(&mut self, checksum: u16) {
-        self.check = checksum.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, check, checksum) }
     }
 
     /// Returns the source address field.
@@ -227,13 +242,15 @@ impl Ipv6Hdr {
     /// Returns the payload length.
     #[inline]
     pub fn payload_len(&self) -> u16 {
-        u16::from_be_bytes(self.payload_len)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, payload_len, u16) }
     }
 
     /// Sets the payload length.
     #[inline]
     pub fn set_payload_len(&mut self, len: u16) {
-        self.payload_len = len.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, payload_len, len) }
     }
 
     /// Returns the source address field.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,54 @@ pub mod tcp;
 pub mod udp;
 pub mod vlan;
 pub mod vxlan;
+
+/// Gets the value of the given big-endian field using pointer arithmetic, raw
+/// pointer conversion and, if the target is little-endian, the `swap_bytes`
+/// method. That performs better than `from_be_bytes`.
+///
+/// # Safety
+///
+/// Caller needs to ensure that the provided field name is in bounds of the struct.
+#[cfg(target_endian = "big")]
+#[macro_export]
+macro_rules! getter_be {
+    ($self:expr, $field:ident, $ty:ty) => {
+        ::core::ptr::read_unaligned(
+            (($self as *const Self as usize) + ::memoffset::offset_of!(Self, $field)) as *const $ty,
+        )
+    };
+}
+#[cfg(target_endian = "little")]
+#[macro_export]
+macro_rules! getter_be {
+    ($self:expr, $field:ident, $ty:ty) => {
+        ::core::ptr::read_unaligned(
+            (($self as *const Self as usize) + ::memoffset::offset_of!(Self, $field)) as *const $ty,
+        )
+        .swap_bytes()
+    };
+}
+
+/// Sets the value of the given big-endian field using pointer arithmetic, raw
+/// pointer conversion and, if the target is litte-endian, the `swap_bytes`
+/// method. That performs better than `to_be_bytes`.
+///
+/// # Safety
+///
+/// Caller needs to ensure that the provided field name is in bounds of the struct.
+#[cfg(target_endian = "big")]
+#[macro_export]
+macro_rules! setter_be {
+    ($self:expr, $field:ident, $val:expr) => {
+        // SAFETY: Pointer arithmetics in bounds of the given struct.
+        $self.$field = *((&$val as *const _ as usize) as *const _);
+    };
+}
+#[cfg(target_endian = "little")]
+#[macro_export]
+macro_rules! setter_be {
+    ($self:expr, $field:ident, $val:expr) => {
+        // SAFETY: Pointer arithmetics in bounds of the given struct.
+        $self.$field = *((&$val.swap_bytes() as *const _ as usize) as *const _)
+    };
+}

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,5 +1,7 @@
 use core::mem;
 
+use crate::{getter_be, setter_be};
+
 /// UDP header, which is present after the IP header.
 ///
 /// This struct represents the User Datagram Protocol (UDP) header as defined in RFC 768.
@@ -49,7 +51,8 @@ impl UdpHdr {
     /// The source port as a u16 value.
     #[inline]
     pub fn src_port(&self) -> u16 {
-        u16::from_be_bytes(self.src)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, src, u16) }
     }
 
     /// Sets the source port number.
@@ -60,8 +63,9 @@ impl UdpHdr {
     /// # Parameters
     /// * `source` - The source port number to set.
     #[inline]
-    pub fn set_src_port(&mut self, source: u16) {
-        self.src = source.to_be_bytes();
+    pub fn set_src_port(&mut self, src: u16) {
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, src, src) }
     }
 
     /// Returns the destination port number.
@@ -73,7 +77,8 @@ impl UdpHdr {
     /// The destination port as a u16 value.
     #[inline]
     pub fn dst_port(&self) -> u16 {
-        u16::from_be_bytes(self.dst)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, dst, u16) }
     }
 
     /// Sets the destination port number.
@@ -85,8 +90,9 @@ impl UdpHdr {
     /// * `dest` - The destination port number to set.
     /// ```
     #[inline]
-    pub fn set_dst_port(&mut self, dest: u16) {
-        self.dst = dest.to_be_bytes();
+    pub fn set_dst_port(&mut self, dst: u16) {
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, dst, dst) }
     }
 
     /// Returns the length of the UDP datagram in bytes.
@@ -99,7 +105,8 @@ impl UdpHdr {
     /// The length as a u16 value.
     #[inline]
     pub fn len(&self) -> u16 {
-        u16::from_be_bytes(self.len)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, len, u16) }
     }
 
     /// Returns true if the UDP length field is zero.
@@ -122,7 +129,8 @@ impl UdpHdr {
     /// * `len` - The length to set in bytes.
     #[inline]
     pub fn set_len(&mut self, len: u16) {
-        self.len = len.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, len, len) }
     }
 
     /// Returns the UDP checksum.
@@ -135,7 +143,8 @@ impl UdpHdr {
     /// The checksum as a u16 value.
     #[inline]
     pub fn checksum(&self) -> u16 {
-        u16::from_be_bytes(self.check)
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, check, u16) }
     }
 
     /// Sets the UDP checksum.
@@ -150,7 +159,8 @@ impl UdpHdr {
     /// * `check` - The checksum value to set.
     #[inline]
     pub fn set_checksum(&mut self, check: u16) {
-        self.check = check.to_be_bytes();
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { setter_be!(self, check, check) }
     }
 }
 

--- a/src/vlan.rs
+++ b/src/vlan.rs
@@ -1,4 +1,4 @@
-use crate::eth::EtherType;
+use crate::{eth::EtherType, getter_be};
 use core::mem;
 
 /// VLAN tag header structure
@@ -15,22 +15,28 @@ pub struct VlanHdr {
 impl VlanHdr {
     pub const LEN: usize = mem::size_of::<VlanHdr>();
 
+    #[inline]
+    fn tci(&self) -> u16 {
+        // SAFETY: Pointer arithmetic in bounds of the struct.
+        unsafe { getter_be!(self, tci, u16) }
+    }
+
     /// Extract the Priority Code Point (PCP) from the VLAN header
     #[inline]
     pub fn pcp(&self) -> u8 {
-        (u16::from_be_bytes(self.tci) >> 13) as u8
+        (self.tci() >> 13) as u8
     }
 
     /// Extract the Drop Eligible Indicator (DEI) from the VLAN header
     #[inline]
     pub fn dei(&self) -> u8 {
-        ((u16::from_be_bytes(self.tci) >> 12) & 1) as u8
+        ((self.tci() >> 12) & 1) as u8
     }
 
     /// Extract the VLAN ID from the VLAN header
     #[inline]
     pub fn vid(&self) -> u16 {
-        u16::from_be_bytes(self.tci) & 0xFFF
+        self.tci() & 0xFFF
     }
 
     /// Get the EtherType value


### PR DESCRIPTION
Add `getter_be` and `setter_be` macros, which get and set big-endian integer fields, represented as byte arrays, using pointer arithmetic and `swap_bytes`. That performs better than `from_be_bytes` and `to_be_bytes` methods.

Fixes: #69