### PR TITLE
feat(ip): Add `EcnCodepoint` enum

### DIFF
--- a/src/ecn_codepoint.rs
+++ b/src/ecn_codepoint.rs
@@ -1,0 +1,15 @@
+/// Explicit congestion notification codepoint carried in the IP header.
+///
+/// These values correspond to the two-bit ECN field defined by RFC 3168. They occupy the low two
+/// bits of the IPv4 DS field or IPv6 Traffic Class field. To indicate non-ECT codepoint, use `None`
+/// for `Option<EcnCodepoint>`.
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum EcnCodepoint {
+    /// ECN Capable Transport, codepoint 0.
+    Ect0 = 0b10,
+    /// ECN Capable Transport, codepoint 1.
+    Ect1 = 0b01,
+    /// Indicates congestion to the end nodes, set by router.
+    Ce = 0b11,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod arp;
 pub mod bitfield;
+pub mod ecn_codepoint;
 pub mod eth;
 pub mod geneve;
 pub mod icmp;


### PR DESCRIPTION
Add a dedicated `EcnCodepoint` type for RFC 3168 ECN values (`Ect0`, `Ect1`, `Ce`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vadorovsky/network-types/85)
<!-- Reviewable:end -->
